### PR TITLE
Merge register definitions from stm32h7-sdmmc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,29 @@
+name: Continuous integration
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.41.0  # MSRV
+        include:
+          - rust: nightly
+            experimental: true
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          #     target: thumbv7em-none-eabihf
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          # use-cross: true
+          command: test
+          args: --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,3 @@ categories = [
     "embedded",
     "no-std",
 ]
-
-[dependencies]
-bitfield = "0.13.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
 name = "sdio-host"
 version = "0.2.0"
-authors = ["Johan Kristell <johan@jott.se>"]
+authors = ["Johan Kristell <johan@jott.se>",
+           "Richard Meadows <richard@richard.fish>"]
 edition = "2018"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jkristell/sdio-host"
-description = "Sd host protocol library"
+description = "SD host protocol library"
 keywords = [
     "sd",
     "sdio",
+    "sdmmc",
 ]
 categories = [
     "embedded",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,8 +553,6 @@ impl RCA {
 }
 
 /// Card interface condition (R7)
-///
-/// R6
 #[derive(Copy, Clone, Default)]
 pub struct CIC(u32);
 impl From<u32> for CIC {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! SD Card Registers
 //!
-//! Register represenations can be created from an array of little endian
+//! Register representations can be created from an array of little endian
 //! words. Note that the SDMMC protocol transfers the registers in big endian
 //! byte order.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
 
 use core::{fmt, str};
 
-use bitfield::bitfield;
-
 /// Types of SD Card
 #[derive(Debug, Copy, Clone)]
 #[non_exhaustive]
@@ -533,24 +531,44 @@ impl fmt::Debug for SDStatus {
     }
 }
 
-bitfield! {
-    #[derive(Copy, Clone, Default)]
-    /// Relative Card Address (R6)
-    pub struct Rca(u32);
-    impl Debug;
-    /// Get the address of the card
-    pub u16, address, _: 31, 16;
-    pub u16, status, set_status: 15, 0;
+/// Relative Card Address (RCA)
+///
+/// R6
+#[derive(Copy, Clone, Default)]
+pub struct RCA(u32);
+impl From<u32> for RCA {
+    fn from(word: u32) -> Self {
+        Self(word)
+    }
+}
+impl RCA {
+    /// Address of card
+    pub fn address(&self) -> u16 {
+        (self.0 >> 16) as u16
+    }
+    /// Status
+    pub fn status(&self) -> u16 {
+        self.0 as u16
+    }
 }
 
-bitfield! {
-    #[derive(Copy, Clone, Default)]
-    /// Card interface condiftion (R7)
-    pub struct Cic(u32);
-    impl Debug;
-    /// The voltage ranges the card accepts
-    /// 0b0001 2.7 - 3.6 V
-    pub u8, voltage_accepted, _: 11, 8;
-    /// Echo-back of the check pattern
-    pub u8, checkpattern, _: 7, 0;
+/// Card interface condition (R7)
+///
+/// R6
+#[derive(Copy, Clone, Default)]
+pub struct CIC(u32);
+impl From<u32> for CIC {
+    fn from(word: u32) -> Self {
+        Self(word)
+    }
+}
+impl CIC {
+    /// The voltage range the card accepts
+    pub fn voltage_accepted(&self) -> u8 {
+        (self.0 >> 8) as u8
+    }
+    /// Echo-back check pattern
+    pub fn pattern(&self) -> u8 {
+        self.0 as u8
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,38 @@
+//! SD Card Registers
+//!
+//! Register represenations can be created from an array of little endian
+//! words. Note that the SDMMC protocol transfers the registers in big endian
+//! byte order.
+//!
+//! ```
+//! # use sdio_host::SCR;
+//! let scr: SCR = [0, 1].into();
+//! ```
+
 #![no_std]
+
+use core::{fmt, str};
 
 use bitfield::bitfield;
 
+/// Types of SD Card
 #[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum CardCapacity {
     /// Standard Capacity (< 2Gb)
     SDSC,
     /// High capacity (< 32Gb)
     SDHC,
 }
+impl Default for CardCapacity {
+    fn default() -> Self {
+        CardCapacity::SDSC
+    }
+}
 
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum SdSpecVersion {
+pub enum SDSpecVersion {
     /// Version 1.0 and and 1.0.1
     V1_0,
     /// Version 1.10
@@ -22,194 +43,486 @@ pub enum SdSpecVersion {
     V3,
     /// Version 4.0
     V4,
-    Unsupported,
+    /// Version 5.0
+    V5,
+    /// Version 6.0
+    V6,
+    /// Version 7.0
+    V7,
+    /// Version not known by this crate
+    Unknown,
 }
 
-bitfield! {
-    #[derive(Copy, Clone, Default)]
-    /// Card power status (R3)
-    pub struct Ocr(u32);
-    impl Debug;
-    /// Voltage range 2.7 - 2.8 supported
-    pub v27_28, _: 15;
-    /// Voltage range 2.8 - 2.9 supported
-    pub v28_29, _: 16;
-    /// Voltage range 2.9 - 3.0 supported
-    pub v29_30, _: 17;
-    /// Voltage range 3.0 - 3.1 supported
-    pub v30_31, _: 18;
-    /// Voltage range 3.1 - 3.2 supported
-    pub v31_32, _: 19;
-    /// Voltage range 3.2 - 3.3 supported
-    pub v32_33, _: 20;
-    /// Voltage range 3.3 - 3.4 supported
-    pub v33_34, _: 21;
-    /// Voltage range 3.4 - 3.5 supported
-    pub v34_35, _: 22;
-    /// Voltage range 3.5 - 3.6 supported
-    pub v35_36, _: 23;
-    /// Switching to 1.8V Accepted (Only UHS-I card supports this bit)
-    pub v18_allowed, _: 24;
-    /// Over 2TB support Status (Only SDUC card supports this bit)
-    pub over_2tb, _: 27;
-    pub uhs2_card_status, _: 29;
-    /// Card capacity, valid after power up
-    /// True if SDHC or SDXC card is found, false for SDSC
-    pub high_capacity, _: 30;
-    /// Set to true when card has finished the power up routine
-    pub powered, _: 31;
+/// The number of data lines in use on the SDMMC bus
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(missing_docs)]
+pub enum BusWidth {
+    #[non_exhaustive]
+    Unknown,
+    One = 1,
+    Four = 4,
+    Eight = 8,
 }
 
-bitfield! {
-    #[derive(Copy, Clone, Default)]
-    /// Card identification (R2)
-    pub struct Cid([u32]);
-    impl Debug;
-    pub u8, crc7, _: 7, 1;
-    pub u16, date, _: 19, 8;
-    pub u32, serial, _: 55, 24;
-    pub u64, name, _: 103, 64;
-    pub u16, oid, _: 119, 104;
-    pub u8, mid, _: 127, 120;
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BlockSize {
+    #[non_exhaustive]
+    Unknown = 0,
+    B512 = 9,
+    B1024 = 10,
+    B2048 = 11,
 }
 
-impl Cid<[u32; 4]> {
-    pub fn name_bytes(&self) -> [u8; 5] {
-        let bytes = self.name().to_be_bytes();
-        let mut ret = [0u8; 5];
-        ret.copy_from_slice(&bytes[3..]);
-        ret
-    }
-
-    pub fn oem(&self) -> [u8; 2] {
-        self.oid().to_be_bytes()
-    }
+#[derive(Copy, Clone)]
+#[allow(non_camel_case_types)]
+pub enum CurrentConsumption {
+    I_0mA,
+    I_1mA,
+    I_5mA,
+    I_10mA,
+    I_25mA,
+    I_35mA,
+    I_45mA,
+    I_60mA,
+    I_80mA,
+    I_100mA,
+    I_200mA,
 }
-
-bitfield! {
-    #[derive(Copy, Clone, Default)]
-    /// Sd memory card configuration
-    pub struct Scr([u32]);
-    impl Debug;
-    pub u8, sd_spec, _: 59, 56;
-    /// Note: Memory cards should support both 1 and 4 wide bus
-    pub u8, bus_widths, _: 51, 48;
-    pub bool, sd_spec3, _: 47;
-    pub bool, sd_spec4, _: 42;
-    pub u8, sd_spec5, _: 41, 38;
-}
-
-impl Scr<[u32; 2]> {
-    pub fn version(&self) -> SdSpecVersion {
-        match (self.sd_spec(), self.sd_spec3(), self.sd_spec4()) {
-            (0, false, false) => SdSpecVersion::V1_0,
-            (1, false, false) => SdSpecVersion::V1_10,
-            (2, false, false) => SdSpecVersion::V2,
-            (2, true, false) => SdSpecVersion::V3,
-            (2, true, true) => SdSpecVersion::V4,
-            _ => SdSpecVersion::Unsupported,
+impl From<&CurrentConsumption> for u32 {
+    fn from(i: &CurrentConsumption) -> u32 {
+        match i {
+            CurrentConsumption::I_0mA => 0,
+            CurrentConsumption::I_1mA => 1,
+            CurrentConsumption::I_5mA => 5,
+            CurrentConsumption::I_10mA => 10,
+            CurrentConsumption::I_25mA => 25,
+            CurrentConsumption::I_35mA => 35,
+            CurrentConsumption::I_45mA => 45,
+            CurrentConsumption::I_60mA => 60,
+            CurrentConsumption::I_80mA => 80,
+            CurrentConsumption::I_100mA => 100,
+            CurrentConsumption::I_200mA => 200,
         }
     }
 }
-
-#[derive(Debug, Copy, Clone)]
-pub enum Csd {
-    V1(CsdV1<[u32; 4]>),
-    V2(CsdV2<[u32; 4]>),
-}
-
-impl Csd {
-    pub fn parse(buf: [u32; 4]) -> Option<Csd> {
-        match buf[3] >> 30 {
-            0b00 => Some(Csd::V1(CsdV1(buf))),
-            0b01 => Some(Csd::V2(CsdV2(buf))),
-            0b10 => unimplemented!("V3"),
-            _ => None,
+impl CurrentConsumption {
+    fn from_minimum_reg(reg: u128) -> CurrentConsumption {
+        match reg {
+            0 => CurrentConsumption::I_0mA,
+            1 => CurrentConsumption::I_1mA,
+            2 => CurrentConsumption::I_5mA,
+            3 => CurrentConsumption::I_10mA,
+            4 => CurrentConsumption::I_25mA,
+            5 => CurrentConsumption::I_35mA,
+            6 => CurrentConsumption::I_60mA,
+            _ => CurrentConsumption::I_100mA,
         }
     }
-
-    pub fn card_size(&self) -> u64 {
-        match self {
-            Csd::V1(csd) => csd.card_size(),
-            Csd::V2(csd) => csd.card_size(),
-        }
-    }
-
-    pub fn blocks(&self) -> u32 {
-        match self {
-            Csd::V1(csd) => csd.blocks(),
-            Csd::V2(csd) => csd.blocks(),
+    fn from_maximum_reg(reg: u128) -> CurrentConsumption {
+        match reg {
+            0 => CurrentConsumption::I_0mA,
+            1 => CurrentConsumption::I_5mA,
+            2 => CurrentConsumption::I_10mA,
+            3 => CurrentConsumption::I_25mA,
+            4 => CurrentConsumption::I_35mA,
+            5 => CurrentConsumption::I_45mA,
+            6 => CurrentConsumption::I_80mA,
+            _ => CurrentConsumption::I_200mA,
         }
     }
 }
-
-bitfield! {
-    #[derive(Copy, Clone, Default)]
-    /// Card identification (Version 1) (R2)
-    pub struct CsdV1([u32]);
-    impl Debug;
-
-    ///  (C_SIZE)
-    pub u16, device_size, _: 73, 62;
-    /// (C_SIZE_MULT)
-    pub u8, device_size_multiplier, _: 49, 47;
-    /// (READ_BL_LEN)
-    pub u8, read_block_len, _: 83, 80;
-    pub u8, version, _: 127, 126;
-}
-
-bitfield! {
-    #[derive(Copy, Clone, Default)]
-    /// Card identification (Version 2) (R2)
-    pub struct CsdV2([u32]);
-    impl Debug;
-    pub u32, device_size, _: 69, 48;
-    pub u8, version, _: 127, 126;
-}
-
-impl CsdV1<[u32; 4]> {
-    pub fn card_size(&self) -> u64 {
-        let blocks = self.blocks();
-        let blk_len: u64 = 1u64 << self.read_block_len() as u64;
-        (blocks as u64 * blk_len) as u64
-    }
-
-    pub fn blocks(&self) -> u32 {
-        let blocks: u32 = 1u32 + (self.device_size() as u32);
-        let multiplier: u32 = 1 << (2u32 + (self.device_size_multiplier() as u32));
-        blocks * multiplier
+impl fmt::Debug for CurrentConsumption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ma: u32 = self.into();
+        write!(f, "{} mA", ma)
     }
 }
 
-impl CsdV2<[u32; 4]> {
+/// Operation Conditions Register (OCR)
+///
+/// R3
+#[derive(Clone, Copy, Default)]
+pub struct OCR(u32);
+impl From<u32> for OCR {
+    fn from(word: u32) -> Self {
+        Self(word)
+    }
+}
+impl OCR {
+    /// VDD voltage window
+    pub fn voltage_window_mv(&self) -> Option<(u16, u16)> {
+        let mut window = (self.0 >> 15) & 0x1FF;
+        let mut min = 2_700;
+
+        while window & 1 == 0 && window != 0 {
+            min += 100;
+            window >>= 1;
+        }
+        let mut max = min;
+        while window != 0 {
+            max += 100;
+            window >>= 1;
+        }
+
+        if max == min {
+            None
+        } else {
+            Some((min, max))
+        }
+    }
+    /// Switching to 1.8V Accepted (S18A). Only UHS-I cards support this bit
+    pub fn v18_allowed(&self) -> bool {
+        self.0 & 0x0100_0000 != 0
+    }
+    /// Over 2TB support Status. Only SDUC card support this bit
+    pub fn over_2tb(&self) -> bool {
+        self.0 & 0x0800_0000 != 0
+    }
+    /// Indicates whether the card supports UHS-II Interface
+    pub fn uhs2_card_status(&self) -> bool {
+        self.0 & 0x2000_0000 != 0
+    }
+    /// Card Capacity Status (CCS). True for SDHC/SDXC/SDUC, false for SDSC
+    pub fn high_capacity(&self) -> bool {
+        self.0 & 0x4000_0000 != 0
+    }
+    /// Card power up status bit (busy)
+    pub fn is_busy(&self) -> bool {
+        self.0 & 0x8000_0000 == 0 // Set active LOW
+    }
+}
+impl fmt::Debug for OCR {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OCR: Operation Conditions Register")
+            .field(
+                "Voltage Window (mV)",
+                &self.voltage_window_mv().unwrap_or((0, 0)),
+            )
+            .field("S18A (UHS-I only)", &self.v18_allowed())
+            .field("UHS-II Card", &self.uhs2_card_status())
+            .field(
+                "CSS",
+                &if self.high_capacity() {
+                    "SDHC/SDXC/SDUC"
+                } else {
+                    "SDSC"
+                },
+            )
+            .field("Busy", &self.is_busy())
+            .finish()
+    }
+}
+
+/// Card Identification Register (CID)
+///
+/// R2
+#[derive(Clone, Copy, Default)]
+pub struct CID {
+    inner: u128,
+    bytes: [u8; 16],
+}
+impl From<u128> for CID {
+    fn from(inner: u128) -> Self {
+        Self {
+            inner,
+            bytes: inner.to_be_bytes(),
+        }
+    }
+}
+/// From little endian words
+impl From<[u32; 4]> for CID {
+    fn from(words: [u32; 4]) -> Self {
+        let inner = ((words[3] as u128) << 96)
+            | ((words[2] as u128) << 64)
+            | ((words[1] as u128) << 32)
+            | words[0] as u128;
+        inner.into()
+    }
+}
+impl CID {
+    /// Manufacturer ID
+    pub fn manufacturer_id(&self) -> u8 {
+        self.bytes[0]
+    }
+    /// OEM/Application ID
+    pub fn oem_id(&self) -> &str {
+        str::from_utf8(&self.bytes[1..3]).unwrap_or(&"<ERR>")
+    }
+    /// Product name
+    pub fn product_name(&self) -> &str {
+        str::from_utf8(&self.bytes[3..8]).unwrap_or(&"<ERR>")
+    }
+    /// Product revision
+    pub fn product_revision(&self) -> u8 {
+        self.bytes[8]
+    }
+    /// Product serial number
+    pub fn serial(&self) -> u32 {
+        (self.inner >> 24) as u32
+    }
+    /// Manufacturing date
+    pub fn manufacturing_date(&self) -> (u8, u16) {
+        (
+            (self.inner >> 8) as u8 & 0xF,             // Month
+            ((self.inner >> 12) as u16 & 0xFF) + 2000, // Year
+        )
+    }
+    #[allow(unused)]
+    fn crc7(&self) -> u8 {
+        (self.bytes[15] >> 1) & 0x7F
+    }
+}
+impl fmt::Debug for CID {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CID: Card Identification")
+            .field("Manufacturer ID", &self.manufacturer_id())
+            .field("OEM ID", &self.oem_id())
+            .field("Product Name", &self.product_name())
+            .field("Product Revision", &self.product_revision())
+            .field("Product Serial Number", &self.serial())
+            .field("Manufacturing Date", &self.manufacturing_date())
+            .finish()
+    }
+}
+
+/// SD CARD Configuration Register (SCR)
+#[derive(Clone, Copy, Default)]
+pub struct SCR(pub u64);
+/// From little endian words
+impl From<[u32; 2]> for SCR {
+    fn from(words: [u32; 2]) -> Self {
+        Self(((words[1] as u64) << 32) | words[0] as u64)
+    }
+}
+impl SCR {
+    /// Physical Layer Specification Version Number
+    pub fn version(&self) -> SDSpecVersion {
+        let spec = (self.0 >> 56) & 0xF;
+        let spec3 = (self.0 >> 47) & 1;
+        let spec4 = (self.0 >> 42) & 1;
+        let specx = (self.0 >> 38) & 0xF;
+
+        // Ref PLSS_v7_10 Table 5-17
+        match (spec, spec3, spec4, specx) {
+            (0, 0, 0, 0) => SDSpecVersion::V1_0,
+            (1, 0, 0, 0) => SDSpecVersion::V1_10,
+            (2, 0, 0, 0) => SDSpecVersion::V2,
+            (2, 1, 0, 0) => SDSpecVersion::V3,
+            (2, 1, 1, 0) => SDSpecVersion::V4,
+            (2, 1, _, 1) => SDSpecVersion::V5,
+            (2, 1, _, 2) => SDSpecVersion::V6,
+            (2, 1, _, 3) => SDSpecVersion::V7,
+            _ => SDSpecVersion::Unknown,
+        }
+    }
+    /// Bus widths supported
+    pub fn bus_widths(&self) -> u8 {
+        // Ref PLSS_v7_10 Table 5-21
+        ((self.0 >> 48) as u8) & 0xF
+    }
+    /// Supports 1-bit bus width
+    pub fn bus_width_one(&self) -> bool {
+        (self.0 >> 48) & 1 != 0
+    }
+    /// Supports 4-bit bus width
+    pub fn bus_width_four(&self) -> bool {
+        (self.0 >> 50) & 1 != 0
+    }
+}
+impl fmt::Debug for SCR {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SCR: SD CARD Configuration Register")
+            .field("Version", &self.version())
+            .field("1-bit width", &self.bus_width_one())
+            .field("4-bit width", &self.bus_width_four())
+            .finish()
+    }
+}
+
+/// Card Specific Data (CSD)
+#[derive(Clone, Copy, Default)]
+pub struct CSD(u128);
+impl From<u128> for CSD {
+    fn from(inner: u128) -> Self {
+        Self(inner)
+    }
+}
+/// From little endian words
+impl From<[u32; 4]> for CSD {
+    fn from(words: [u32; 4]) -> Self {
+        let inner = ((words[3] as u128) << 96)
+            | ((words[2] as u128) << 64)
+            | ((words[1] as u128) << 32)
+            | words[0] as u128;
+        inner.into()
+    }
+}
+impl CSD {
+    /// CSD structure version
+    pub fn version(&self) -> u8 {
+        (self.0 >> 126) as u8 & 3
+    }
+    /// Maximum data transfer rate per one data line
+    pub fn tranfer_rate(&self) -> u8 {
+        (self.0 >> 96) as u8
+    }
+    /// Maximum block length. In an SD Memory Card the WRITE_BL_LEN is
+    /// always equal to READ_BL_LEN
+    pub fn block_length(&self) -> BlockSize {
+        // Read block length
+        match (self.0 >> 80) & 0xF {
+            9 => BlockSize::B512,
+            10 => BlockSize::B1024,
+            11 => BlockSize::B2048,
+            _ => BlockSize::Unknown,
+        }
+    }
+    /// Number of blocks in the card
+    pub fn block_count(&self) -> u32 {
+        match self.version() {
+            0 => {
+                // SDSC
+                let c_size: u16 = ((self.0 >> 62) as u16) & 0xFFF;
+                let c_size_mult: u8 = ((self.0 >> 47) as u8) & 7;
+
+                ((c_size + 1) as u32) * ((1 << (c_size_mult + 2)) as u32)
+            }
+            1 => {
+                // SDHC / SDXC
+                (((self.0 >> 48) as u32 & 0x3F_FFFF) + 1) * 1024
+            }
+            2 => {
+                // SDUC
+                (((self.0 >> 48) as u32 & 0xFFF_FFFF) + 1) * 1024
+            }
+            _ => 0,
+        }
+    }
     /// Card size in bytes
-    /// The memory capacity is calculated as (device_size (A.k.a C_SIZE) + 1) * 512kb
     pub fn card_size(&self) -> u64 {
-        self.blocks() as u64 * 512
-    }
+        let block_size_bytes = 1 << self.block_length() as u64;
 
-    /// Number of blocks
-    /// Block size is fixed at 512
-    pub fn blocks(&self) -> u32 {
-        (self.device_size() + 1) * 1024
+        (self.block_count() as u64) * block_size_bytes
+    }
+    /// Maximum read current at the minimum VDD
+    pub fn read_current_minimum_vdd(&self) -> CurrentConsumption {
+        CurrentConsumption::from_minimum_reg(self.0 >> 59)
+    }
+    /// Maximum write current at the minimum VDD
+    pub fn write_current_minimum_vdd(&self) -> CurrentConsumption {
+        CurrentConsumption::from_minimum_reg(self.0 >> 56)
+    }
+    /// Maximum read current at the maximum VDD
+    pub fn read_current_maximum_vdd(&self) -> CurrentConsumption {
+        CurrentConsumption::from_maximum_reg(self.0 >> 53)
+    }
+    /// Maximum write current at the maximum VDD
+    pub fn write_current_maximum_vdd(&self) -> CurrentConsumption {
+        CurrentConsumption::from_maximum_reg(self.0 >> 50)
+    }
+    /// Erase size (in blocks)
+    pub fn erase_size_blocks(&self) -> u32 {
+        if (self.0 >> 46) & 1 == 1 {
+            // ERASE_BLK_EN
+            1
+        } else {
+            let sector_size_tens = (self.0 >> 43) & 0x7;
+            let sector_size_units = (self.0 >> 39) & 0xF;
+
+            (sector_size_tens as u32 * 10) + (sector_size_units as u32)
+        }
+    }
+}
+impl fmt::Debug for CSD {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CSD: Card Specific Data")
+            .field("Tranfer Rate", &self.tranfer_rate())
+            .field("Block Count", &self.block_count())
+            .field("Read I (@min VDD)", &self.read_current_minimum_vdd())
+            .field("Write I (@min VDD)", &self.write_current_minimum_vdd())
+            .field("Read I (@max VDD)", &self.read_current_maximum_vdd())
+            .field("Write I (@max VDD)", &self.write_current_maximum_vdd())
+            .field("Erase Size (Blocks)", &self.erase_size_blocks())
+            .finish()
     }
 }
 
-bitfield! {
-    #[derive(Copy, Clone, Default)]
-    /// Sd Card Status
-    pub struct SdStatus([u32]);
-    impl Debug;
-    /// bus_width
-    pub u8, bus_width, _: 511, 510;
-    /// Secure mode
-    pub bool, secure_mode, _: 509;
-    /// Card type
-    pub u16, sd_card_type, _: 495, 480;
-    pub u32, protected_area_size, _: 479, 448;
-    pub u8, speed_class, _: 447, 440;
-    pub u8, app_perf_class, _: 339, 336;
-    pub bool, discard_support, _: 313;
+/// SD Status
+#[derive(Clone, Copy, Default)]
+pub struct SDStatus {
+    inner: [u32; 16],
+}
+/// From little endian words
+impl From<[u32; 16]> for SDStatus {
+    fn from(inner: [u32; 16]) -> Self {
+        Self { inner }
+    }
+}
+impl SDStatus {
+    /// Current data bus width
+    pub fn bus_width(&self) -> BusWidth {
+        match (self.inner[15] >> 30) & 3 {
+            0 => BusWidth::One,
+            2 => BusWidth::Four,
+            _ => BusWidth::Unknown,
+        }
+    }
+    /// Is the card currently in the secured mode
+    pub fn secure_mode(&self) -> bool {
+        self.inner[15] & 0x2000_0000 != 0
+    }
+    /// SD Memory Card type (ROM, OTP, etc)
+    pub fn sd_memory_card_type(&self) -> u16 {
+        self.inner[15] as u16
+    }
+    /// SDHC / SDXC: Capacity of Protected Area in bytes
+    pub fn protected_area_size(&self) -> u32 {
+        self.inner[14]
+    }
+    /// Speed Class
+    pub fn speed_class(&self) -> u8 {
+        (self.inner[13] >> 24) as u8
+    }
+    /// "Performance Move" indicator in 1 MB/s units
+    pub fn move_performance(&self) -> u8 {
+        (self.inner[13] >> 16) as u8
+    }
+    /// Allocation Unit (AU) size. Lookup in PLSS v7_10 Table 4-47
+    pub fn allocation_unit_size(&self) -> u8 {
+        (self.inner[13] >> 12) as u8 & 0xF
+    }
+    /// Indicates N_Erase, in units of AU
+    pub fn erase_size(&self) -> u16 {
+        (self.inner[13] & 0xFF) as u16 | ((self.inner[12] >> 24) & 0xFF) as u16
+    }
+    /// Indicates T_Erase
+    pub fn erase_timeout(&self) -> u8 {
+        (self.inner[12] >> 18) as u8 & 0x3F
+    }
+    /// Video speed class
+    pub fn video_speed_class(&self) -> u8 {
+        (self.inner[11] & 0xFF) as u8
+    }
+    /// Application Performance Class
+    pub fn app_perf_class(&self) -> u8 {
+        (self.inner[9] >> 16) as u8 & 0xF
+    }
+    /// Discard Support
+    pub fn discard_support(&self) -> bool {
+        self.inner[8] & 0x0200_0000 != 0
+    }
+}
+impl fmt::Debug for SDStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SD Status")
+            .field("Protected Area Size (B)", &self.protected_area_size())
+            .field("Speed Class", &self.speed_class())
+            .field("Move Performance (MB/s)", &self.move_performance())
+            .field("AU Size", &self.allocation_unit_size())
+            .field("Erase Size (AU)", &self.erase_size())
+            .field("Erase Timeout (s)", &self.erase_timeout())
+            .finish()
+    }
 }
 
 bitfield! {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -183,6 +183,65 @@ static CARDS: &[TestCard] = &[
             version: SDSpecVersion::V3,
         },
     },
+    // Sandisk extreme 32Gb Class 10
+    TestCard {
+        cid: [0xc000e344, 0x80f1086b, 0x45333247, 0x03534453],
+        cidr: CidRes {
+            mid: 3,
+            serial: 4043860928,
+            name: "SE32G",
+            oem: "SD",
+            revision: 128,
+            m_month: 3,
+            m_year: 2014,
+        },
+        csd: [0x0a4040c2, 0xedc87f80, 0x5b590000, 0x400e0032],
+        csdr: CsdRes {
+            version: 1,
+            transfer_rate: 50,
+            size_bytes: 31914983424,
+            blocks: 62333952,
+            read_current_minimum_vdd: CurrentConsumption::I_100mA,
+            write_current_minimum_vdd: CurrentConsumption::I_100mA,
+            read_current_maximum_vdd: CurrentConsumption::I_200mA,
+            write_current_maximum_vdd: CurrentConsumption::I_200mA,
+            erase_size_blocks: 1,
+        },
+
+        ocr: 3254747136,
+        ocrr: OcrRes {
+            voltage_window_mv: (2700, 3600),
+            v18_allowed: true,
+            over_2tb: false,
+            uhs2_card_status: false,
+            high_capacity: true,
+            powered: true,
+        },
+
+        status: [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 251992576, 67145728, 83886080, 2147483648,
+        ],
+        statusr: StatusRes {
+            bus_width: BusWidth::Four,
+            secure_mode: false,
+            sd_card_type: 0,
+            protected_area_size: 83886080,
+            speed_class: 4, // Class 10
+            video_speed_class: 0,
+            app_perf_class: 0,
+            move_performance: 0, // Ignore for class 10
+            allocation_unit_size: 9,
+            erase_size: 15,
+            erase_timeout: 1,
+            discard_support: false,
+        },
+
+        scr: [0x00000000, 0x02358001],
+        scrr: ScrRes {
+            bus_widths: 5,
+            version: SDSpecVersion::V3,
+        },
+    },
 ];
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,5 @@
-use sdio_host::{Cid, Csd, Ocr, Scr, SdSpecVersion, SdStatus};
+use sdio_host::{BusWidth, SDSpecVersion};
+use sdio_host::{SDStatus, CID, CSD, OCR, SCR};
 
 struct TestCard {
     cid: [u32; 4],
@@ -28,15 +29,7 @@ struct CsdRes {
 }
 
 struct OcrRes {
-    v27_28: bool,
-    v28_29: bool,
-    v29_30: bool,
-    v30_31: bool,
-    v31_32: bool,
-    v32_33: bool,
-    v33_34: bool,
-    v34_35: bool,
-    v35_36: bool,
+    voltage_window_mv: (u16, u16),
     v18_allowed: bool,
     over_2tb: bool,
     uhs2_card_status: bool,
@@ -45,7 +38,7 @@ struct OcrRes {
 }
 
 struct StatusRes {
-    bus_width: u8,
+    bus_width: BusWidth,
     secure_mode: bool,
     sd_card_type: u16,
     protected_area_size: u32,
@@ -60,7 +53,7 @@ struct ScrRes {
     sd_spec3: bool,
     sd_spec4: bool,
     sd_spec5: u8,
-    version: SdSpecVersion,
+    version: SDSpecVersion,
 }
 
 static CARDS: &[TestCard] = &[
@@ -82,15 +75,7 @@ static CARDS: &[TestCard] = &[
         },
         ocr: 3237969920,
         ocrr: OcrRes {
-            v27_28: true,
-            v28_29: true,
-            v29_30: true,
-            v30_31: true,
-            v31_32: true,
-            v32_33: true,
-            v33_34: true,
-            v34_35: true,
-            v35_36: true,
+            voltage_window_mv: (2700, 3600),
             v18_allowed: false,
             over_2tb: false,
             uhs2_card_status: false,
@@ -102,7 +87,7 @@ static CARDS: &[TestCard] = &[
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 134676480, 33722368, 50331648, 2147483648,
         ],
         statusr: StatusRes {
-            bus_width: 2,
+            bus_width: BusWidth::Four,
             secure_mode: false,
             sd_card_type: 0,
             protected_area_size: 50331648,
@@ -117,7 +102,7 @@ static CARDS: &[TestCard] = &[
             sd_spec3: true,
             sd_spec4: false,
             sd_spec5: 0,
-            version: SdSpecVersion::V3,
+            version: SDSpecVersion::V3,
         },
     },
     // Sandisk 8 Gb Class 4
@@ -139,15 +124,7 @@ static CARDS: &[TestCard] = &[
 
         ocr: 3237969920,
         ocrr: OcrRes {
-            v27_28: true,
-            v28_29: true,
-            v29_30: true,
-            v30_31: true,
-            v31_32: true,
-            v32_33: true,
-            v33_34: true,
-            v34_35: true,
-            v35_36: true,
+            voltage_window_mv: (2700, 3600),
             v18_allowed: false,
             over_2tb: false,
             uhs2_card_status: false,
@@ -159,7 +136,7 @@ static CARDS: &[TestCard] = &[
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 184877056, 33722368, 50331648, 2147483648,
         ],
         statusr: StatusRes {
-            bus_width: 2,
+            bus_width: BusWidth::Four,
             secure_mode: false,
             sd_card_type: 0,
             protected_area_size: 50331648,
@@ -175,7 +152,7 @@ static CARDS: &[TestCard] = &[
             sd_spec3: true,
             sd_spec4: false,
             sd_spec5: 0,
-            version: SdSpecVersion::V3,
+            version: SDSpecVersion::V3,
         },
     },
 ];
@@ -183,69 +160,57 @@ static CARDS: &[TestCard] = &[
 #[test]
 fn test_cid() {
     for card in CARDS {
-        let cid = Cid(card.cid);
+        let cid: CID = card.cid.into();
         println!("{:?}", cid);
 
         assert_eq!(cid.serial(), card.cidr.serial);
-        assert_eq!(cid.mid(), card.cidr.mid);
+        assert_eq!(cid.manufacturer_id(), card.cidr.mid);
 
-        let name_bytes = cid.name_bytes();
-        let name = std::str::from_utf8(&name_bytes).unwrap();
-        assert_eq!(name, card.cidr.name);
-
-        let oemb = cid.oem();
-        let oem = std::str::from_utf8(&oemb).unwrap();
-        assert_eq!(oem, card.cidr.oem);
+        assert_eq!(cid.product_name(), card.cidr.name);
+        assert_eq!(cid.oem_id(), card.cidr.oem);
     }
 }
 
 #[test]
 fn test_csd() {
     for card in CARDS {
-        let csd = Csd::parse(card.csd).unwrap();
+        let csd: CSD = card.csd.into();
+        println!("{:?}", csd);
 
-        if let Csd::V2(csd) = csd {
-            assert_eq!(csd.version(), card.csdr.version);
-            assert_eq!(csd.device_size(), card.csdr.device_size);
-            assert_eq!(csd.blocks(), card.csdr.blocks);
-            assert_eq!(csd.card_size(), card.csdr.size_bytes);
-        } else if let Csd::V1(_csd) = csd {
-        } else {
-            assert!(false);
-        }
+        assert_eq!(csd.version(), card.csdr.version);
+        assert_eq!(csd.block_count(), card.csdr.blocks);
+        assert_eq!(csd.card_size(), card.csdr.size_bytes);
     }
 }
 
 #[test]
 fn test_ocr() {
     for card in CARDS {
-        let ocr = Ocr(card.ocr);
-        assert_eq!(ocr.v27_28(), card.ocrr.v27_28);
-        assert_eq!(ocr.v28_29(), card.ocrr.v28_29);
-        assert_eq!(ocr.v29_30(), card.ocrr.v29_30);
-        assert_eq!(ocr.v30_31(), card.ocrr.v30_31);
-        assert_eq!(ocr.v31_32(), card.ocrr.v31_32);
-        assert_eq!(ocr.v32_33(), card.ocrr.v32_33);
-        assert_eq!(ocr.v33_34(), card.ocrr.v33_34);
-        assert_eq!(ocr.v34_35(), card.ocrr.v34_35);
-        assert_eq!(ocr.v35_36(), card.ocrr.v35_36);
+        let ocr: OCR = card.ocr.into();
+        println!("{:?}", ocr);
+
+        assert_eq!(
+            ocr.voltage_window_mv().unwrap(),
+            card.ocrr.voltage_window_mv
+        );
         assert_eq!(ocr.v18_allowed(), card.ocrr.v18_allowed);
         assert_eq!(ocr.over_2tb(), card.ocrr.over_2tb);
         assert_eq!(ocr.uhs2_card_status(), card.ocrr.uhs2_card_status);
         assert_eq!(ocr.high_capacity(), card.ocrr.high_capacity);
-        assert_eq!(ocr.powered(), card.ocrr.powered);
+        assert_eq!(ocr.is_busy(), !card.ocrr.powered);
     }
 }
 
 #[test]
 fn test_sdstatus() {
     for card in CARDS {
-        let status = SdStatus(card.status);
+        let status: SDStatus = card.status.into();
+        println!("{:?}", status);
 
         let r = &card.statusr;
         assert_eq!(status.bus_width(), r.bus_width);
         assert_eq!(status.secure_mode(), r.secure_mode);
-        assert_eq!(status.sd_card_type(), r.sd_card_type);
+        assert_eq!(status.sd_memory_card_type(), r.sd_card_type);
         assert_eq!(status.protected_area_size(), r.protected_area_size);
         assert_eq!(status.speed_class(), r.speed_class);
         assert_eq!(status.app_perf_class(), r.app_perf_class);
@@ -256,14 +221,11 @@ fn test_sdstatus() {
 #[test]
 fn test_scr() {
     for card in CARDS {
-        let scr = Scr(card.scr);
+        let scr: SCR = card.scr.into();
+        println!("{:?}", scr);
 
         let r = &card.scrr;
-        assert_eq!(scr.sd_spec(), r.sd_spec);
         assert_eq!(scr.bus_widths(), r.bus_widths);
-        assert_eq!(scr.sd_spec3(), r.sd_spec3);
-        assert_eq!(scr.sd_spec4(), r.sd_spec4);
-        assert_eq!(scr.sd_spec5(), r.sd_spec5);
         assert_eq!(scr.version(), r.version);
     }
 }


### PR DESCRIPTION
All definitions continue to assume that the underlying storage is little-endian.

Rename the following methods for clarity/improvement:

`cid.name_bytes()` -> `cid.product_name()`
`cid.mid()` -> `cid.manufacturer_id()`
`cid.oem()` -> `cid.oem_id()`
`ocr.vXX_XX()` group -> `ocr.voltage_window_mv()`
`ocr.powered()` -> !`ocr.is_busy()`
`status.sd_card_type()` -> `status.sd_memory_card_type()`

Removed intermediary fields that are unlikely to be of interest to end-users:

`csd.device_size()`
`scr.sd_spec()` (use `scr.version()`)
`scr.sd_specX()`

All existing tests pass.

TODO:
* ~~Add new fields to tests~~
* ~~Add new fields to `Debug` implementations~~
* ~~Implement `Rca` / `Cic` in the same style~~