### PR TITLE
Fix ACMD41. Closes #5

### DIFF
--- a/src/sd_cmd.rs
+++ b/src/sd_cmd.rs
@@ -68,17 +68,19 @@ pub fn sd_status() -> Cmd<R1> {
 /// * `host_high_capacity_support` - Host supports high capacity cards
 /// * `sdxc_power_control` - Controls the maximum power and default speed mode of SDXC and SDUC cards
 /// * `switch_to_1_8v_request` - Switch to 1.8V signaling
-/// * `voltage_window` - Bitwise voltage window supported by the host
+/// * `voltage_window` - 9-bit bitfield that represents the voltage window
+/// supported by the host. Use 0x1FF to indicate support for the full range of
+/// voltages
 pub fn sd_send_op_cond(
     host_high_capacity_support: bool,
     sdxc_power_control: bool,
     switch_to_1_8v_request: bool,
-    voltage_window: u32,
+    voltage_window: u16,
 ) -> Cmd<R3> {
     let arg = u32::from(host_high_capacity_support) << 30
         | u32::from(sdxc_power_control) << 28
         | u32::from(switch_to_1_8v_request) << 24
-        | voltage_window & 0x00FF_8000;
+        | u32::from(voltage_window & 0x1FF) << 15;
     cmd(41, arg)
 }
 

--- a/src/sd_cmd.rs
+++ b/src/sd_cmd.rs
@@ -65,15 +65,20 @@ pub fn sd_status() -> Cmd<R1> {
 
 /// ACMD41: App Op Command
 ///
-/// * `high_capacity` - Host supports high capacity cards
-/// * `xpc` - Controls the maximum power and default speed mode of SDXC and SDUC cards.
-/// * `s18r` - Switch to 1.8V signaling
-/// * `voltage_window` - The voltage window the host supports.
-pub fn sd_send_op_cond(high_capacity: bool, xpc: bool, s18r: bool, voltage_window: u32) -> Cmd<R3> {
-    let arg = u32::from(high_capacity) << 30
-        | u32::from(xpc) << 28
-        | u32::from(s18r) << 24
-        | voltage_window & 0x00FF_FFFF;
+/// * `host_high_capacity_support` - Host supports high capacity cards
+/// * `sdxc_power_control` - Controls the maximum power and default speed mode of SDXC and SDUC cards
+/// * `switch_to_1_8v_request` - Switch to 1.8V signaling
+/// * `voltage_window` - Bitwise voltage window supported by the host
+pub fn sd_send_op_cond(
+    host_high_capacity_support: bool,
+    sdxc_power_control: bool,
+    switch_to_1_8v_request: bool,
+    voltage_window: u32,
+) -> Cmd<R3> {
+    let arg = u32::from(host_high_capacity_support) << 30
+        | u32::from(sdxc_power_control) << 28
+        | u32::from(switch_to_1_8v_request) << 24
+        | voltage_window & 0x00FF_8000;
     cmd(41, arg)
 }
 


### PR DESCRIPTION
* Restrict bitwise voltage window to valid values only
* Name the function and its arguments using words, not a jumble of letters