### PR TITLE
Fix VDD_*_CURR_MAX conversion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ impl CurrentConsumption {
     }
     fn from_maximum_reg(reg: u128) -> CurrentConsumption {
         match reg {
-            0 => CurrentConsumption::I_0mA,
+            0 => CurrentConsumption::I_1mA,
             1 => CurrentConsumption::I_5mA,
             2 => CurrentConsumption::I_10mA,
             3 => CurrentConsumption::I_25mA,


### PR DESCRIPTION
In the process of investigating #7, I found this discrepancy from the eMMC spec. In reality, the CURR_MIN and CURR_MAX fields have identical semantics between SD cards and eMMC devices, there was just a small error in the code.