### PR TITLE
Use `u64` for block count.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -395,7 +395,7 @@ impl<Ext> CardStatus<Ext> {
 /// Relative Card Address (RCA)
 ///
 /// R6
-#[derive(Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct RCA<Ext>(pub(crate) u32, PhantomData<Ext>);
 impl<Ext> From<u32> for RCA<Ext> {
     fn from(word: u32) -> Self {

--- a/src/common.rs
+++ b/src/common.rs
@@ -304,7 +304,7 @@ impl<Ext> CSD<Ext> {
 /// Error and state information of an executed command
 ///
 /// Ref PLSS_v7_10 Section 4.10.1
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct CardStatus<Ext>(pub(crate) u32, PhantomData<Ext>);
 
 impl<Ext> From<u32> for CardStatus<Ext> {

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -225,7 +225,7 @@ impl CSD<SD> {
     pub fn card_size(&self) -> u64 {
         let block_size_bytes = 1 << self.block_length() as u64;
 
-        (self.block_count() as u64) * block_size_bytes
+        self.block_count() * block_size_bytes
     }
     /// Erase size (in blocks)
     pub fn erase_size_blocks(&self) -> u32 {

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -201,22 +201,22 @@ impl fmt::Debug for CID<SD> {
 
 impl CSD<SD> {
     /// Number of blocks in the card
-    pub fn block_count(&self) -> u32 {
+    pub fn block_count(&self) -> u64 {
         match self.version() {
             0 => {
                 // SDSC
                 let c_size: u16 = ((self.0 >> 62) as u16) & 0xFFF;
                 let c_size_mult: u8 = ((self.0 >> 47) as u8) & 7;
 
-                ((c_size + 1) as u32) * ((1 << (c_size_mult + 2)) as u32)
+                ((c_size + 1) as u64) * ((1 << (c_size_mult + 2)) as u64)
             }
             1 => {
-                // SDHC / SDXC
-                (((self.0 >> 48) as u32 & 0x3F_FFFF) + 1) * 1024
+                // SDHC/SDXC
+                (((self.0 >> 48) as u64 & 0x3F_FFFF) + 1) * 1024
             }
             2 => {
                 // SDUC
-                (((self.0 >> 48) as u32 & 0xFFF_FFFF) + 1) * 1024
+                (((self.0 >> 48) as u64 & 0xFFF_FFFF) + 1) * 1024
             }
             _ => 0,
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -26,7 +26,7 @@ struct CidRes {
 struct CsdRes {
     version: u8,
     transfer_rate: u8,
-    blocks: u32,
+    blocks: u64,
     size_bytes: u64,
     read_current_minimum_vdd: CurrentConsumption,
     write_current_minimum_vdd: CurrentConsumption,


### PR DESCRIPTION
The maximum values for SDHC/SDXC and SDUC don't fit in `u32`.

Also closes https://github.com/jkristell/sdio-host/issues/11.